### PR TITLE
Implementing Dark Mode - #issue4

### DIFF
--- a/src/main/java/com/nadyagrishina/reflect_diary/secutiry/SecurityConfig.java
+++ b/src/main/java/com/nadyagrishina/reflect_diary/secutiry/SecurityConfig.java
@@ -38,6 +38,7 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.GET, "/auth/register").permitAll()
                         .requestMatchers(HttpMethod.POST, "/auth/register").permitAll()
                         .requestMatchers("/css/**", "/fonts/**").permitAll()
+                        .requestMatchers("/js/**").permitAll()
                         .anyRequest().authenticated())
                 .formLogin(form -> form
                         .loginPage("/auth/login")

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -44,6 +44,11 @@
 
     --soft-red: #f28b82;
     --soft-blue: #64b5f6;
+
+    --chip-bg: #eee;
+    --chip-text: #000;
+    --chip-bg-checked: #d16d6d;
+    --chip-text-checked: #fff;
 }
 
 * {
@@ -161,6 +166,13 @@ input::placeholder{
     transition: all 0.3s ease;
     font-weight: 700;
     background: linear-gradient(135deg, var(--main-color), var(--main-color-hover));
+}
+
+body.dark-mode {
+  --chip-bg: #2e2e2e;
+  --chip-text: #fff;
+  --chip-bg-checked: var(--main-color-hover-dark-mode);
+  --chip-text-checked: #fff;
 }
 
 body.dark-mode .login__content button[type="submit"],
@@ -573,15 +585,16 @@ body.dark-mode .entries__link{
     display: inline-block;
     padding: 6px 12px;
     border-radius: 16px;
-    background-color: #eee;
+    background-color: var(--chip-bg);
+    color: var(--chip-text);
     cursor: pointer;
     user-select: none;
-    transition: background-color 0.2s ease;
+    transition: background-color 0.2s ease, color 0.2s ease;
 }
 
 .chip input[type="checkbox"]:checked + span {
-    background-color: #d16d6d;
-    color: white;
+    background-color: var(--chip-bg-checked);
+    color: var(--chip-text-checked);
 }
 
 
@@ -650,16 +663,33 @@ body.dark-mode .entry__help-text {
     color: #cccccc;
 }
 
-body.dark-mode .goal__desc {
-    color: #ffffff
-}
-
 body.dark-mode  label{
     color: #f0f0f0;
 }
 
 body.dark-mode a{
 color: #f0f0f0
+}
+
+body.dark-mode .entry-details__content {
+    background-color: #1e1e1e;
+    color: #f0f0f0;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+}
+
+body.dark-mode .entry-details__info h3 {
+    border-left: 2px solid var(--main-color);
+    color: #ffffff;
+}
+
+body.dark-mode .tag__item {
+    background-color: #333;
+    color: #f0f0f0;
+}
+
+body.dark-mode .goal__desc,
+body.dark-mode .entry__desc {
+    color: #f0f0f0;
 }
 
 

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -39,6 +39,8 @@
     --details-color: #D4C2A8;
     --placeholder-color: #777;
     --input-border: #D4C2A8;
+    --accent-color-dark-mode: #88B6A5;
+    --main-color-hover-dark-mode: #E16B73;
 
     --soft-red: #f28b82;
     --soft-blue: #64b5f6;
@@ -161,12 +163,28 @@ input::placeholder{
     background: linear-gradient(135deg, var(--main-color), var(--main-color-hover));
 }
 
+body.dark-mode .login__content button[type="submit"],
+.register__content button[type="submit"],
+.create-entry__form button[type="submit"],
+.create-goal__form button[type="submit"]{
+    background: linear-gradient(135deg, var(--main-color), var(--main-color-hover-dark-mode));
+}
+
 
 .login__content button[type="submit"]:hover,
 .register__content button[type="submit"]:hover,
 .create-entry__form button[type="submit"]:hover,
 .create-goal__form button[type="submit"]:hover{
     background-color: var(--main-color-hover);
+    transform: scale(1.03);
+    box-shadow: 0 4px 10px rgba(90, 10, 135, 0.3);
+}
+
+body.dark-mode .login__content button[type="submit"]:hover,
+.register__content button[type="submit"]:hover,
+.create-entry__form button[type="submit"]:hover,
+.create-goal__form button[type="submit"]:hover{
+    background-color: var(--main-color-hover-dark-mode);
     transform: scale(1.03);
     box-shadow: 0 4px 10px rgba(90, 10, 135, 0.3);
 }
@@ -243,6 +261,10 @@ input::placeholder{
     transform: scale(1.03);
     background-color: var(--main-color-hover);
     box-shadow: 0 4px 10px rgba(90, 10, 135, 0.3);
+}
+
+body.dark-mode .profile__create-link:hover {
+    background-color: var(--main-color-hover-dark-mode);
 }
 
 .profile__logout-link {
@@ -340,6 +362,10 @@ input::placeholder{
     border-left: 2px solid var(--main-color-hover)
 }
 
+body.dark-mode .entry__item {
+    border-left: 2px solid var(--main-color-hover-dark-mode)
+}
+
 .entry__item a {
     display: block;
 }
@@ -417,6 +443,10 @@ input::placeholder{
 .entries__link{
     background-color: var(--main-color-hover);
 }
+
+body.dark-mode .entries__link{
+    background-color: var(--main-color-hover-dark-mode);
+    }
 
 .profile__info {
     background: white;
@@ -583,19 +613,15 @@ input::placeholder{
 }
 
 body.dark-mode {
-  background-color: #121212;
+  background-color: #1e1e1e;
   color: #e0e0e0;
-}
-
-body.dark-mode {
-    background-color: #121212;
-    color: #f0f0f0;
+  background-image: none;
 }
 
 body.dark-mode h1,
 body.dark-mode h2,
 body.dark-mode h3 {
-    color: var(--accent-color);
+    color: var(--accent-color-dark-mode);
 }
 
 body.dark-mode input,

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -563,8 +563,77 @@ input::placeholder{
     margin-right: 3px;
 }
 
+.dark-mode-toggle-wrapper {
+    position: fixed;
+    top: 10px;
+    right: 10px; !i
+    z-index: 1000;
+}
+
+#toggleDarkMode {
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: inherit;
+  transition: transform 0.5s ease;
+}
+
+#toggleDarkMode:hover {
+  transform: scale(1.2);
+}
+
 body.dark-mode {
   background-color: #121212;
   color: #e0e0e0;
 }
+
+body.dark-mode {
+    background-color: #121212;
+    color: #f0f0f0;
+}
+
+body.dark-mode h1,
+body.dark-mode h2,
+body.dark-mode h3 {
+    color: var(--accent-color);
+}
+
+body.dark-mode input,
+body.dark-mode textarea,
+body.dark-mode select {
+    background-color: #1e1e1e;
+    color: #ffffff;
+    border: 1px solid #444;
+}
+
+body.dark-mode button {
+    color: #ffffff;
+}
+
+body.dark-mode .profile__card,
+body.dark-mode .profile__info,
+body.dark-mode .goal__item,
+body.dark-mode .entry__item {
+    background-color: #1a1a1a;
+    border-color: #333;
+    color: #ffffff;
+}
+
+body.dark-mode .goal__help-text,
+body.dark-mode .entry__help-text {
+    color: #cccccc;
+}
+
+body.dark-mode .goal__desc {
+    color: #ffffff
+}
+
+body.dark-mode  label{
+    color: #f0f0f0;
+}
+
+body.dark-mode a{
+color: #f0f0f0
+}
+
 

--- a/src/main/resources/static/js/darkmode.js
+++ b/src/main/resources/static/js/darkmode.js
@@ -1,11 +1,21 @@
-const toggle = document.getElementById('dark-toggle');
-const theme = localStorage.getItem('theme');
+document.addEventListener('DOMContentLoaded', () => {
+    const toggleBtn = document.getElementById("toggleDarkMode");
+    if (!toggleBtn) return;
 
-if (theme === 'dark' || (!theme && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
-  document.body.classList.add('dark-mode');
-}
+    if (localStorage.getItem("darkMode") === "true") {
+        document.body.classList.add("dark-mode");
+    }
 
-toggle?.addEventListener('click', () => {
-  document.body.classList.toggle('dark-mode');
-  localStorage.setItem('theme', document.body.classList.contains('dark-mode') ? 'dark' : 'light');
+    updateIcon();
+
+    toggleBtn.addEventListener("click", () => {
+        const isDark = document.body.classList.toggle("dark-mode");
+        localStorage.setItem("darkMode", isDark);
+        updateIcon();
+    });
+
+    function updateIcon() {
+        const isDark = document.body.classList.contains("dark-mode");
+        toggleBtn.textContent = isDark ? "☀️" : "🌓";
+    }
 });

--- a/src/main/resources/templates/create-entry.html
+++ b/src/main/resources/templates/create-entry.html
@@ -4,9 +4,12 @@
     <meta charset="UTF-8">
     <title>Reflect-Diary</title>
     <link rel="stylesheet" th:href="@{/css/style.css}"/>
-    <script th:src="@{/js/script.js}" defer></script>
+    <script th:src="@{/js/darkmode.js}" defer></script>
 </head>
-<body>
+<body th:attr="data-logged-in=${#authorization.expression('isAuthenticated()')}">
+<div class="dark-mode-toggle-wrapper">
+    <button id="toggleDarkMode" title="Toggle dark mode">🌓</button>
+</div>
 <main>
     <div class="container">
         <a th:href="@{/}">

--- a/src/main/resources/templates/create-goal.html
+++ b/src/main/resources/templates/create-goal.html
@@ -4,16 +4,18 @@
     <meta charset="UTF-8">
     <title>Reflect-Diary</title>
     <link rel="stylesheet" th:href="@{/css/style.css}"/>
-    <script th:src="@{/js/script.js}" defer></script>
+    <script th:src="@{/js/darkmode.js}" defer></script>
 </head>
-<body>
+<body th:attr="data-logged-in=${#authorization.expression('isAuthenticated()')}">
+<div class="dark-mode-toggle-wrapper">
+    <button id="toggleDarkMode" title="Toggle dark mode">🌓</button>
+</div>
 <main>
     <div class="create-goal__content container">
         <a th:href="@{/}">
             <h1>Reflect-Diary</h1>
         </a>
         <div class="create-goal__form--wrapper">
-            <button id="dark-toggle">🌙 Dark Mode</button>
             <div><h2>Create/Update Goal</h2></div>
             <form th:object="${goal}"
                   th:action="@{${formAction}}"

--- a/src/main/resources/templates/entries.html
+++ b/src/main/resources/templates/entries.html
@@ -4,9 +4,12 @@
     <meta charset="UTF-8">
     <title>Reflect-Diary</title>
     <link rel="stylesheet" th:href="@{/css/style.css}"/>
-    <script th:src="@{/js/script.js}" defer></script>
+    <script th:src="@{/js/darkmode.js}" defer></script>
 </head>
 <body>
+<div class="dark-mode-toggle-wrapper">
+    <button id="toggleDarkMode" title="Toggle dark mode">🌓</button>
+</div>
 <main class="container">
     <a th:href="@{/}">
         <h1>Reflect-Diary</h1>

--- a/src/main/resources/templates/entry-details.html
+++ b/src/main/resources/templates/entry-details.html
@@ -4,9 +4,12 @@
     <meta charset="UTF-8">
     <title>Reflect-Diary</title>
     <link rel="stylesheet" th:href="@{/css/style.css}"/>
-    <script th:src="@{/js/script.js}" defer></script>
+    <script th:src="@{/js/darkmode.js}" defer></script>
 </head>
 <body>
+<div class="dark-mode-toggle-wrapper">
+    <button id="toggleDarkMode" title="Toggle dark mode">🌓</button>
+</div>
 <main class="container entry-details">
     <a th:href="@{/}">
         <h1>Reflect-Diary</h1>

--- a/src/main/resources/templates/goals.html
+++ b/src/main/resources/templates/goals.html
@@ -4,9 +4,12 @@
     <meta charset="UTF-8">
     <title>Reflect-Diary</title>
     <link rel="stylesheet" th:href="@{/css/style.css}"/>
-    <script th:src="@{/js/script.js}" defer></script>
+    <script th:src="@{/js/darkmode.js}" defer></script>
 </head>
 <body>
+<div class="dark-mode-toggle-wrapper">
+    <button id="toggleDarkMode" title="Toggle dark mode">🌓</button>
+</div>
 <main class="container">
     <a th:href="@{/}">
         <h1>Reflect-Diary</h1>

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -4,9 +4,12 @@
     <meta charset="UTF-8">
     <title>Reflect-Diary</title>
     <link rel="stylesheet" th:href="@{/css/style.css}"/>
-    <script th:src="@{/js/script.js}" defer></script>
+    <script th:src="@{/js/darkmode.js}" defer></script>
 </head>
 <body>
+<div class="dark-mode-toggle-wrapper">
+    <button id="toggleDarkMode" title="Toggle dark mode">🌓</button>
+</div>
 <main class="page-wrapper">
     <div class="container">
         <a th:href="@{/}">

--- a/src/main/resources/templates/login.html
+++ b/src/main/resources/templates/login.html
@@ -4,9 +4,12 @@
     <meta charset="UTF-8">
     <title>Reflect-Diary</title>
     <link rel="stylesheet" th:href="@{/css/style.css}"/>
-    <script th:src="@{/js/script.js}" defer></script>
+    <script th:src="@{/js/darkmode.js}" defer></script>
 </head>
-<body>
+<body th:attr="data-logged-in=${#authorization.expression('isAuthenticated()')}">
+<div class="dark-mode-toggle-wrapper">
+    <button id="toggleDarkMode" title="Toggle dark mode">🌓</button>
+</div>
 <main>
     <div class="container login__content">
         <h1>Sign in</h1>
@@ -27,7 +30,7 @@
                    maxlength="100"/>
             <button type="submit">Login</button>
         </form>
-        <p class="login__text">Don't have an account? <a th:href="@{/auth/register}">Create an account</a></p>
+        <p class="login__text">Don't have an account? <a th:href="@{/auth/register}" >Create an account</a></p>
     </div>
 </main>
 

--- a/src/main/resources/templates/register.html
+++ b/src/main/resources/templates/register.html
@@ -4,9 +4,12 @@
     <meta charset="UTF-8">
     <title>Reflect-Diary</title>
     <link rel="stylesheet" th:href="@{/css/style.css}"/>
-    <script th:src="@{/js/script.js}" defer></script>
+    <script th:src="@{/js/darkmode.js}" defer></script>
 </head>
-<body>
+<body th:attr="data-logged-in=${#authorization.expression('isAuthenticated()')}">
+<div class="dark-mode-toggle-wrapper">
+    <button id="toggleDarkMode" title="Toggle dark mode">🌓</button>
+</div>
 <main>
     <div class="container register__content">
         <h1>Create an account</h1>


### PR DESCRIPTION
This patch used both local as database storage to store user preference for dark mode. Local storage is being used for anonymous users (users that are not logged in) Database storage used for authenticated users.
CSS has been modified to improve readibility
A minimal  button has been addded to the top right corner.

This PR attempts to solve #4 

I will add screenshots to the PR.
<img width="1509" alt="Screenshot 2025-07-06 at 19 21 24" src="https://github.com/user-attachments/assets/318154ac-2b94-4c23-a00a-8707e21a09c0" />
<img width="1501" alt="Screenshot 2025-07-06 at 19 21 33" src="https://github.com/user-attachments/assets/e16d8a02-58ec-415d-b5ab-02df45f64a94" />
<img width="1505" alt="Screenshot 2025-07-06 at 19 21 41" src="https://github.com/user-attachments/assets/7463707a-dd99-4be1-8fbb-4b8df8d61f2c" />
<img width="1508" alt="Screenshot 2025-07-06 at 19 21 49" src="https://github.com/user-attachments/assets/1c9e0b98-2ede-4581-8fca-1ab9ee807708" />
<img width="1495" alt="Screenshot 2025-07-06 at 19 22 27" src="https://github.com/user-attachments/assets/79707751-0e8c-4ff6-a2fe-3af0531c8bf8" />
<img width="1511" alt="Screenshot 2025-07-06 at 19 23 06" src="https://github.com/user-attachments/assets/af193f72-6cb8-425e-887f-378e84842984" />
<img width="1512" alt="Screenshot 2025-07-06 at 19 23 14" src="https://github.com/user-attachments/assets/c72e770e-5ae0-4175-a053-62fbc4adcd23" />
